### PR TITLE
Adds recovery.bin to replace starfive-tools input.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,32 @@
         '';
       };
 
+      firmware-vf2-recovery = self.linkFarm "firmware-vf2-recovery" [
+        {
+          name = "jh7110-recovery.bin";
+          path = self.fetchurl {
+            url = "https://github.com/starfive-tech/Tools/raw/master/recovery/jh7110-recovery-20230322.bin";
+            hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
+          };
+        }
+        {
+          name = "u-boot-spl.bin.normal.out";
+          path = "${self.firmware-vf2-upstream}/u-boot-spl.bin.normal.out";
+        }
+        {
+          name = "visionfive2_fw_payload.img";
+          path = "${self.firmware-vf2-upstream}/visionfive2_fw_payload.img";
+        }
+      ];
+
       firmware-vf2-vendor = self.linkFarm "firmware-vf2-vendor" [
+        {
+          name = "jh7110-recovery.bin";
+          path = self.fetchurl {
+            url = "https://github.com/starfive-tech/Tools/raw/master/recovery/jh7110-recovery-20230322.bin";
+            hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
+          };
+        }
         {
           name = "u-boot-spl.bin.normal.out";
           path = self.fetchurl {
@@ -99,6 +124,13 @@
 
       firmware-vf2-edk2-vendor = self.linkFarm "firmware-vf2-edk2-vendor" [
         {
+          name = "jh7110-recovery.bin";
+          path = self.fetchurl {
+            url = "https://github.com/starfive-tech/Tools/raw/master/recovery/jh7110-recovery-20230322.bin";
+            hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
+          };
+        }
+        {
           name = "u-boot-spl.bin.normal.out";
           path = self.fetchurl {
             url = "https://github.com/starfive-tech/edk2/releases/download/REL_VF2_JUN2023-stable202302/u-boot-spl.bin.normal.out";
@@ -115,17 +147,14 @@
       ];
 
       flash-visionfive2-upstream = self.callPackage ./flash-visionfive2.nix {
-        starfive-tools = inputs.starfive-tools;
-        firmware-vf2 = self.firmware-vf2-upstream;
+        firmware-vf2 = self.firmware-vf2-recovery;
       };
 
       flash-visionfive2-vendor = self.callPackage ./flash-visionfive2.nix {
-        starfive-tools = inputs.starfive-tools;
         firmware-vf2 = self.firmware-vf2-vendor;
       };
 
       flash-visionfive2-edk2-vendor = self.callPackage ./flash-visionfive2.nix {
-        starfive-tools = inputs.starfive-tools;
         firmware-vf2 = self.firmware-vf2-edk2-vendor;
       };
     };
@@ -237,7 +266,7 @@
         overlays = [ inputs.self.overlays.firmware ];
       };
       flash-visionfive2-upstream = pkgs.flash-visionfive2-upstream.override {
-        firmware-vf2 = pkgsCross.firmware-vf2-upstream;
+        firmware-vf2 = pkgsCross.firmware-vf2-recovery;
       };
     in {
       inherit flash-visionfive2-upstream;
@@ -246,6 +275,7 @@
       inherit (pkgs) firmware-vf2-vendor;
       inherit (pkgs) firmware-vf2-edk2-vendor;
       inherit (pkgsCross) firmware-vf2-upstream;
+      inherit (pkgsCross) firmware-vf2-recovery;
       nixos-cross = inputs.self.nixosConfigurations.nixos-cross.config.system.build.toplevel;
       nixos-cross-image-efi = inputs.self.nixosConfigurations.nixos-cross-image-efi.config.system.build.efiImage;
       nixos-cross-image-iso = inputs.self.nixosConfigurations.nixos-cross-image-iso.config.system.build.isoImage;

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,12 @@
       });
     };
 
-    overlays.firmware = self: super: {
+    overlays.firmware = self: super: let
+      recovery-bin = self.fetchurl {
+        url = "https://github.com/starfive-tech/Tools/raw/0747c0510e090f69bf7d2884f44903b77b3db5c5/recovery/jh7110-recovery-20230322.bin";
+        hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
+      };
+    in {
       uboot-vf2 = (super.buildUBoot rec {
         version = "2024.04";
         src = super.fetchurl {
@@ -83,10 +88,7 @@
       firmware-vf2-recovery = self.linkFarm "firmware-vf2-recovery" [
         {
           name = "jh7110-recovery.bin";
-          path = self.fetchurl {
-            url = "https://github.com/starfive-tech/Tools/raw/0747c0510e090f69bf7d2884f44903b77b3db5c5/recovery/jh7110-recovery-20230322.bin";
-            hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
-          };
+          path = recovery-bin;
         }
         {
           name = "u-boot-spl.bin.normal.out";
@@ -101,10 +103,7 @@
       firmware-vf2-vendor = self.linkFarm "firmware-vf2-vendor" [
         {
           name = "jh7110-recovery.bin";
-          path = self.fetchurl {
-            url = "https://github.com/starfive-tech/Tools/raw/0747c0510e090f69bf7d2884f44903b77b3db5c5/recovery/jh7110-recovery-20230322.bin";
-            hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
-          };
+          path = recovery-bin;
         }
         {
           name = "u-boot-spl.bin.normal.out";
@@ -125,10 +124,7 @@
       firmware-vf2-edk2-vendor = self.linkFarm "firmware-vf2-edk2-vendor" [
         {
           name = "jh7110-recovery.bin";
-          path = self.fetchurl {
-            url = "https://github.com/starfive-tech/Tools/raw/0747c0510e090f69bf7d2884f44903b77b3db5c5/recovery/jh7110-recovery-20230322.bin";
-            hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
-          };
+          path = recovery-bin;
         }
         {
           name = "u-boot-spl.bin.normal.out";

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
         {
           name = "jh7110-recovery.bin";
           path = self.fetchurl {
-            url = "https://github.com/starfive-tech/Tools/raw/master/recovery/jh7110-recovery-20230322.bin";
+            url = "https://github.com/starfive-tech/Tools/raw/0747c0510e090f69bf7d2884f44903b77b3db5c5/recovery/jh7110-recovery-20230322.bin";
             hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
           };
         }
@@ -102,7 +102,7 @@
         {
           name = "jh7110-recovery.bin";
           path = self.fetchurl {
-            url = "https://github.com/starfive-tech/Tools/raw/master/recovery/jh7110-recovery-20230322.bin";
+            url = "https://github.com/starfive-tech/Tools/raw/0747c0510e090f69bf7d2884f44903b77b3db5c5/recovery/jh7110-recovery-20230322.bin";
             hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
           };
         }
@@ -126,7 +126,7 @@
         {
           name = "jh7110-recovery.bin";
           path = self.fetchurl {
-            url = "https://github.com/starfive-tech/Tools/raw/master/recovery/jh7110-recovery-20230322.bin";
+            url = "https://github.com/starfive-tech/Tools/raw/0747c0510e090f69bf7d2884f44903b77b3db5c5/recovery/jh7110-recovery-20230322.bin";
             hash = "sha256-HIr7ftdgXnr1SFagIvgCGcqa1NrrDECjIPxHFj/52eQ=";
           };
         }

--- a/flash-visionfive2.nix
+++ b/flash-visionfive2.nix
@@ -4,7 +4,6 @@
 , lrzsz
 , picocom
 , expect
-, starfive-tools
 , firmware-vf2
 }:
 let
@@ -15,7 +14,7 @@ let
     expect "CC"
     send "\x01\x13"
     expect "*** file:"
-    send "${starfive-tools}/recovery/jh7110-recovery-20230322.bin"
+    send "${firmware-vf2}/jh7110-recovery.bin"
     send "\r"
     expect "Transfer complete"
 


### PR DESCRIPTION
The bootloader flashing scripts still depended on `inputs.starfive-tools`, which was removed in 3500c7b7. This PR replaces that input with a link to download just the recovery.bin from https://github.com/starfive-tech/Tools as part of the firmware packages.

I marked this as a draft because while typing this I realized I get the recovery.bin from the master branch of the starfive-tools repository... I'll switch that to a specific commit shortly and then mark this as ready.

- [x] Switch starfive-tech/Tools URL to use a specific commit.